### PR TITLE
Fixed bug: Shallow copy of CImgException

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -2256,9 +2256,17 @@ namespace cimg_library_suffixed {
     CImgException(const char *const format, ...) {
       _message = new char[16384]; *_message = 0; _cimg_exception_err("CImgException",true);
     }
+    CImgException(const CImgException& exception) {
+        _message = new char[16384]; 
+        strncpy(_message, exception._message, 16383);
+        _message[16383] = '\0';
+    }
     ~CImgException() throw() { delete[] _message; }
     //! Return a C-string containing the error message associated to the thrown exception.
     const char *what() const throw() { return _message; }
+
+  private:
+    void operator=(const CImgException& exception);
   };
 
   // The CImgInstanceException class is used to throw an exception related


### PR DESCRIPTION
Dear dtschump,

I had faced with small problem of catching the CImgException.
I by mistake, caught it without reference and it produced double free of allocated memory.
I created a small fix for it and hope that it would be helpful.

Thanks,
m0stik