### PR TITLE
examples Makefile: split CFLAGS to DEFINE, INCDIR

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -137,11 +137,15 @@ endif
 ifeq ($(notdir $(CC)),icpc)
 CIMG_OPENMP_CFLAGS = #-Dcimg_use_openmp -openmp -i-static    # -> Seems to bug the compiler!
 else
-CIMG_OPENMP_CFLAGS = -Dcimg_use_openmp -fopenmp
+CIMG_OPENMP_DEFINE = -Dcimg_use_openmp -fopenmp
+CIMG_OPENMP_INCDIR =
+CIMG_OPENMP_CFLAGS = $(CIMG_OPENMP_DEFINE) $(CIMG_OPENMP_INCDIR)
 endif
 
 # Flags to enable OpenCV support.
-CIMG_OPENCV_CFLAGS = -Dcimg_use_opencv -I/usr/include/opencv
+CIMG_OPENCV_DEFINE = -Dcimg_use_opencv
+CIMG_OPENCV_INCDIR = -I/usr/include/opencv
+CIMG_OPENCV_CFLAGS = $(CIMG_OPENCV_DEFINE) $(CIMG_OPENCV_INCDIR)
 CIMG_OPENCV_LIBS = -lopencv_core -lopencv_highgui
 #CIMG_OPENCV_LIBS = -lcv -lhighgui    #-> Use this for OpenCV < 2.2.0
 
@@ -151,7 +155,9 @@ CIMG_NODISPLAY_CFLAGS = -Dcimg_display=0
 # Flags to enable the use of the X11 library.
 # (X11 is used by CImg to handle display windows)
 # !!! For 64bits systems : replace -L$(X11PATH)/lib by -L$(X11PATH)/lib64 !!!
-CIMG_X11_CFLAGS = -I$(X11PATH)/include
+CIMG_X11_DEFINE =
+CIMG_X11_INCDIR = -I$(X11PATH)/include
+CIMG_X11_CFLAGS = $(CIMG_X11_DEFINE) $(CIMG_X11_INCDIR)
 CIMG_X11_LIBS = -L$(X11PATH)/lib -lpthread -lX11
 
 # Flags to enable fast image display, using the XSHM library (when using X11).
@@ -160,63 +166,87 @@ CIMG_XSHM_CFLAGS = # -Dcimg_use_xshm
 CIMG_XSHM_LIBS = # -lXext
 
 # Flags to enable GDI32 display (Windows native).
-CIMG_GDI32_CFLAGS = -mwindows
+CIMG_GDI32_DEFINE = -mwindows
+CIMG_GDI32_INCDIR =
+CIMG_GDI32_CFLAGS = $(CIMG_GDI32_DEFINE) $(CIMG_GDI32_INCDIR)
 CIMG_GDI32_LIBS = -lgdi32
 
 # Flags to enable screen mode switching, using the XRandr library (when using X11).
 # ( http://www.x.org/wiki/Projects/XRandR )
 # !!! Not supported by the X11 server on MacOSX, so do not use it on MacOSX !!!
-CIMG_XRANDR_CFLAGS = -Dcimg_use_xrandr
+CIMG_XRANDR_DEFINE = -Dcimg_use_xrandr
+CIMG_XRANDR_INCDIR =
+CIMG_XRANDR_CFLAGS = $(CIMG_XRANDR_DEFINE) $(CIMG_XRANDR_INCDIR)
 CIMG_XRANDR_LIBS = -lXrandr
 
 # Flags to enable native support for PNG image files, using the PNG library.
 # ( http://www.libpng.org/ )
-CIMG_PNG_CFLAGS = -Dcimg_use_png
+CIMG_PNG_DEFINE = -Dcimg_use_png
+CIMG_PNG_INCDIR =
+CIMG_PNG_CFLAGS = $(CIMG_PNG_DEFINE) $(CIMG_PNG_INCDIR)
 CIMG_PNG_LIBS = -lpng -lz
 
 # Flags to enable native support for JPEG image files, using the JPEG library.
 # ( http://www.ijg.org/ )
-CIMG_JPEG_CFLAGS = -Dcimg_use_jpeg
+CIMG_JPEG_DEFINE = -Dcimg_use_jpeg
+CIMG_JPEG_INCDIR =
+CIMG_JPEG_CFLAGS = $(CIMG_JPEG_DEFINE) $(CIMG_JPEG_INCDIR)
 CIMG_JPEG_LIBS = -ljpeg
 
 # Flags to enable native support for TIFF image files, using the TIFF library.
 # ( http://www.libtiff.org/ )
-CIMG_TIFF_CFLAGS = -Dcimg_use_tiff
+CIMG_TIFF_DEFINE = -Dcimg_use_tiff
+CIMG_TIFF_INCDIR =
+CIMG_TIFF_CFLAGS = $(CIMG_TIFF_DEFINE) $(CIMG_TIFF_INCDIR)
 CIMG_TIFF_LIBS = -ltiff
 
 # Flags to enable native support for MINC2 image files, using the MINC2 library.
 # ( http://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_Users_Guide )
-CIMG_MINC2_CFLAGS = -Dcimg_use_minc2 -I${HOME}/local/include
+CIMG_MINC2_DEFINE = -Dcimg_use_minc2
+CIMG_MINC2_INCDIR = -I${HOME}/local/include
+CIMG_MINC2_CFLAGS = $(CIMG_MINC2_DEFINE) $(CIMG_MINC2_INCDIR)
 CIMG_MINC2_LIBS = -lminc_io -lvolume_io2 -lminc2 -lnetcdf -lhdf5 -lz -L${HOME}/local/lib
 
 # Flags to enable native support for EXR image files, using the OpenEXR library.
 # ( http://www.openexr.com/ )
-CIMG_EXR_CFLAGS = -Dcimg_use_openexr -I/usr/include/OpenEXR
+CIMG_EXR_DEFINE = -Dcimg_use_openexr
+CIMG_EXR_INCDIR = -I/usr/include/OpenEXR
+CIMG_EXR_CFLAGS = $(CIMG_EXR_DEFINE) $(CIMG_EXR_INCDIR)
 CIMG_EXR_LIBS = -lIlmImf -lHalf
 
 # Flags to enable native support for various video files, using the FFMPEG library.
 # ( http://www.ffmpeg.org/ )
-CIMG_FFMPEG_CFLAGS = -Dcimg_use_ffmpeg -D__STDC_CONSTANT_MACROS -I/usr/include/libavcodec -I/usr/include/libavformat -I/usr/include/libswscale -I/usr/include/ffmpeg
+CIMG_FFMPEG_DEFINE = -Dcimg_use_ffmpeg -D__STDC_CONSTANT_MACROS
+CIMG_FFMPEG_INCDIR = -I/usr/include/libavcodec -I/usr/include/libavformat -I/usr/include/libswscale -I/usr/include/ffmpeg
+CIMG_FFMPEG_CFLAGS = $(CIMG_FFMPEG_DEFINE) $(CIMG_FFMPEG_INCDIR)
 CIMG_FFMPEG_LIBS = -lavcodec -lavformat -lswscale
 
 # Flags to enable native support for compressed .cimgz files, using the Zlib library.
 # ( http://www.zlib.net/ )
-CIMG_ZLIB_CFLAGS = -Dcimg_use_zlib
+CIMG_ZLIB_DEFINE = -Dcimg_use_zlib
+CIMG_ZLIB_INCDIR =
+CIMG_ZLIB_CFLAGS = $(CIMG_ZLIB_DEFINE) $(CIMG_ZLIB_INCDIR)
 CIMG_ZLIB_LIBS = -lz
 
 # Flags to enable native support for downloading files from the network.
 # ( http://curl.haxx.se/libcurl/ )
-CIMG_CURL_CFLAGS = -Dcimg_use_curl
+CIMG_CURL_DEFINE = -Dcimg_use_curl
+CIMG_CURL_INCDIR =
+CIMG_CURL_CFLAGS = $(CIMG_CURL_DEFINE)
 CIMG_CURL_LIBS = -lcurl
 
 # Flags to enable native support of most classical image file formats, using the Magick++ library.
 # ( http://www.imagemagick.org/Magick++/ )
-CIMG_MAGICK_CFLAGS = -Dcimg_use_magick `Magick++-config --cppflags` `Magick++-config --cxxflags`
+CIMG_MAGICK_DEFINE = -Dcimg_use_magick
+CIMG_MAGICK_INCDIR = `Magick++-config --cppflags` `Magick++-config --cxxflags`
+CIMG_MAGICK_CFLAGS = $(CIMG_MAGICK_DEFINE) $(CIMG_MAGICK_INCDIR)
 CIMG_MAGICK_LIBS = `Magick++-config --ldflags` `Magick++-config --libs`
 
 # Flags to enable faster Discrete Fourier Transform computation, using the FFTW3 library
 # ( http://www.fftw.org/ )
-CIMG_FFTW3_CFLAGS = -Dcimg_use_fftw3
+CIMG_FFTW3_DEFINE = -Dcimg_use_fftw3
+CIMG_FFTW3_INCDIR =
+CIMG_FFTW3_CFLAGS = $(CIMG_FFTW3_DEFINE) $(CIMG_FFTW3_INCDIR)
 ifeq ($(OSTYPE),msys)
 CIMG_FFTW3_LIBS = -lfftw3-3
 else
@@ -225,12 +255,16 @@ endif
 
 # Flags to enable the use of LAPACK routines for matrix computation
 # ( http://www.netlib.org/lapack/ )
-CIMG_LAPACK_CFLAGS = -Dcimg_use_lapack
+CIMG_LAPACK_DEFINE = -Dcimg_use_lapack
+CIMG_LAPACK_INCDIR =
+CIMG_LAPACK_CFLAGS = $(CIMG_LAPACK_DEFINE) $(CIMG_LAPACK_INCDIR)
 CIMG_LAPACK_LIBS = -lblas -lg2c -llapack
 
 # Flags to enable the use of the Board library
 # ( http://libboard.sourceforge.net/ )
-CIMG_BOARD_CFLAGS = -Dcimg_use_board -I/usr/include/board
+CIMG_BOARD_DEFINE = -Dcimg_use_board
+CIMG_BOARD_INCDIR = -I/usr/include/board
+CIMG_BOARD_CFLAGS = $(CIMG_BOARD_DEFINE) $(CIMG_BOARD_INCDIR)
 CIMG_BOARD_LIBS = -lboard
 
 # Flags to compile on Sun Solaris


### PR DESCRIPTION
Changes of INCDIR (-I) and DEFINE (-D, -m, -f) are now independent.
It is convenient for cross-compilation with MinGW.

See also https://github.com/mxe/mxe/pull/877