### PR TITLE
use minimal Windows include

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -159,6 +159,9 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #ifndef _WIN32_IE
 #define _WIN32_IE 0x0400


### PR DESCRIPTION
I'm not quite sure if there's some plugin or feature that needs the full version, but I didn't encounter anything (but I would argue that if there some extra stuff needed it should be included manually).

The reason for this is that when we used CImg together with boost asio there was some conflict with CImg pulling in winsock. 