### PR TITLE
Add abs specialization for unsigned long.

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -4689,6 +4689,9 @@ namespace cimg_library_suffixed {
     inline int abs(const unsigned int a) {
       return (int)a;
     }
+    inline long abs(const unsigned long a) {
+      return (long)a;
+    }
     inline int abs(const int a) {
       return std::abs(a);
     }


### PR DESCRIPTION
unsigned long is distinct form unsigned int on many platforms and if this specialization isn't present, it can result in a compiler error.