### PR TITLE
Fix unbounded malloc DoS in PNM loading code

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -52367,6 +52367,14 @@ namespace cimg_library_suffixed {
       }
       std::fgetc(nfile);
 
+      const cimg_uint64 size_limit = (cimg_uint64)2 * 1024 * 1024 * 1024;
+      if ((cimg_uint64)W * (cimg_uint64)H >= size_limit) {
+          throw CImgIOException(_cimg_instance
+              "load_pnm(): WIDTH * HEIGHT exceeds limit of" cimg_fuint64 " in file '%s'.",
+              cimg_instance,
+              (cimg_uint64)W * (cimg_uint64)H, filename ? filename : "(FILE*)");
+      }
+
       switch (ppm_type) {
       case 1 : { // 2D B&W ascii
         assign(W,H,1,1);


### PR DESCRIPTION
The PNM parsing code reads the width and height fields and will allocate
an appropriate CImg instance. Since this is done before reading the data
and without a size check on the input file, even a very short PNM file
can cause a huge allocation. Especially on 64bit platforms, the PNM
loading code will allocate huge amounts of memory when supplied with
huge W and H values, e.g. this PNM input will allocate 16GB and spend a
lot of time in the parsing loop:
P2
131072 131072
255

This can be considered a DoS since an attacker has to only supply a very
short amount of data to case a huge ressource usage.

This PR limits the maximum size of the image (W*H) to 2 G pixels.