### PR TITLE
add heic and avif support via libheif

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -618,6 +618,10 @@ extern "C" {
 }
 #endif
 
+#ifdef cimg_use_heic
+#include <libheif/heif_cxx.h>
+#endif
+
 // Check if min/max/PI macros are defined.
 //
 // CImg does not compile if macros 'min', 'max' or 'PI' are defined,
@@ -51479,6 +51483,8 @@ namespace cimg_library_suffixed {
                  !cimg::strcasecmp(ext,"raf") ||
                  !cimg::strcasecmp(ext,"srf")) load_dcraw_external(filename);
         else if (!cimg::strcasecmp(ext,"gif")) load_gif_external(filename);
+        else if (!cimg::strcasecmp(ext,"heic") ||
+                 !cimg::strcasecmp(ext,"avif")) load_heic(filename);
 
         // 3D binary formats
         else if (!cimg::strcasecmp(ext,"dcm") ||
@@ -54201,6 +54207,79 @@ namespace cimg_library_suffixed {
     static CImg<T> get_load_gif_external(const char *const filename,
                                          const char axis='z', const float align=0) {
       return CImgList<T>().load_gif_external(filename).get_append(axis,align);
+    }
+
+    //! Load image from a HEIC file.
+    /**
+       \param filename Filename, as a C-string.
+    **/
+    CImg<T>& load_heic(const char *const filename) {
+      return _load_heic(filename);
+    }
+
+    //! Load image from a HEIC file \newinstance.
+    static CImg<T> get_load_heic(const char *const filename) {
+      return CImg<T>().load_heic(filename);
+    }
+
+    CImg<T>& _load_heic(const char *const filename) {
+#ifndef cimg_use_heic
+      throw CImgArgumentException(_cimg_instance
+                                  "load_heic(): Specified filename is (null).",
+                                  cimg_instance);
+      return load_other(filename);
+#else
+      try {
+        heif::Context ctx;
+        ctx.read_from_file(filename);
+
+        auto handle = ctx.get_primary_image_handle();
+        auto image = handle.decode_image(heif_colorspace_RGB, handle.has_alpha_channel() ? heif_chroma_interleaved_RGBA : heif_chroma_interleaved_RGB);
+
+        int width = image.get_width(heif_channel_interleaved);
+        int height = image.get_height(heif_channel_interleaved);
+        int depth = 1;
+        int spectrum = handle.has_alpha_channel() ? 4 : 3;
+
+        int stride;
+        uint8_t* data = image.get_plane(heif_channel_interleaved, &stride);
+
+        CImg<uint8_t> buffer(data, width, height, depth, spectrum);
+        assign(width, height, depth, spectrum);
+
+        T *ptr_r = _data, *ptr_g = _data + 1UL*_width*_height, *ptr_b = _data + 2UL*_width*_height,
+          *ptr_a = _data + 3UL*_width*_height;
+        for (size_t i = 0; i < height; ++i)
+        {
+          const uint8_t *ptrs = buffer._data + i * stride;
+          switch (_spectrum) {
+          case 3 : {
+            cimg_forX(*this,x) {
+              *(ptr_r++) = (T)*(ptrs++);
+              *(ptr_g++) = (T)*(ptrs++);
+              *(ptr_b++) = (T)*(ptrs++);
+            }
+          } break;
+          case 4 : {
+            cimg_forX(*this,x) {
+              *(ptr_r++) = (T)*(ptrs++);
+              *(ptr_g++) = (T)*(ptrs++);
+              *(ptr_b++) = (T)*(ptrs++);
+              *(ptr_a++) = (T)*(ptrs++);
+            }
+          } break;
+          }
+        }
+      } catch (const heif::Error& e) {
+        throw CImgInstanceException(_cimg_instance
+                                   "load_heic(): Unable to decode image: %s",
+                                   cimg_instance, e.get_message());
+      } catch (...) {
+        throw;
+      }
+
+      return *this;
+#endif
     }
 
     //! Load image using GraphicsMagick's external tool 'gm'.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -106,6 +106,9 @@ SET(CIMG_MAGICK_CCFLAGS -Dcimg_use_magick)
 # ( http://www.fftw.org/ )
 SET(CIMG_FFTW3_CCFLAGS  -Dcimg_use_fftw3)
 
+# Flags to enable native support for HEIC image files, using libheif.
+# ( https://github.com/strukturag/libheif )
+SET(CIMG_HEIC_CCFLAGS  -Dcimg_use_heic)
 
 
 
@@ -117,6 +120,22 @@ FIND_PACKAGE(PNG)
 FIND_PACKAGE(ZLIB)
 FIND_PACKAGE(LAPACK)
 FIND_PACKAGE(BLAS)
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_HEIF libheif QUIET)
+endif()
+
+find_path(HEIF_INCLUDE_DIR NAMES libheif/heif_cxx.h
+                           PATHS ${PC_HEIF_INCLUDEDIR})
+find_library(HEIF_LIBRARY NAMES heif libheif
+                          PATHS ${PC_HEIF_LIBDIR})
+
+set(HEIF_VERSION ${PC_HEIF_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HEIF
+                                  REQUIRED_VARS HEIF_LIBRARY HEIF_INCLUDE_DIR
+                                  VERSION_VAR HEIF_VERSION)
 
 PKG_CHECK_MODULES(FFTW3 fftw3)
 PKG_CHECK_MODULES(OPENEXR OpenEXR)
@@ -200,7 +219,13 @@ if(MAGICK_FOUND)
   SET( SYSTEM_LIBS ${SYSTEM_LIBS} ${MAGICK_LIBRARIES} )
 endif()
 
-
+if(HEIF_FOUND)
+  get_filename_component(HEIF_LIB_DIRS ${HEIF_LIBRARY} PATH)
+  SET(CIMG_CFLAGS "${CIMG_CFLAGS} ${CIMG_HEIC_CCFLAGS}")
+  link_directories( ${HEIF_LIB_DIRS} )
+  include_directories( ${HEIF_INCLUDE_DIRS} )
+  SET( SYSTEM_LIBS ${SYSTEM_LIBS} ${HEIF_LIBRARY} )
+endif()
 
 
 if( LIBAVCODEC_FOUND  AND LIBAVFORMAT_FOUND AND LIBSWSCALE_FOUND AND LIBAVUTIL_FOUND )


### PR DESCRIPTION
Hello!

I've added support for heic files via libheif -> https://github.com/strukturag/libheif

I wanted to implement this because of this project
https://gitlab.com/opennota/phash
which is used by this project
https://gitlab.com/opennota/findimagedupes

I've tested this using the example `tutorial` program.

I tried to follow some of the style but I do find it hard to read. If you are interested in this PR just let me know what I can do to improve the formatting.

I'm also not 100% sure I've implemented this correctly
```
        CImg<uint8_t> buffer(data, width, height, depth, spectrum);
        assign(width, height, depth, spectrum);
```
From what I gather the constructor will create a new buffer and copy the data into it (it's hard for me to read the templates). Then the `assign` makes sure `this` has the correct values. Then later the pointers for the data are updated.

Tested:
 - RGB heic image

Not Tested:
 - RGBA heic image
 - avif images (libheif advertises support for avif images using the exact same api)