### PR TITLE
delete -mtune option on loongarch architecture

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -153,7 +153,11 @@ VT100_CFLAGS = -Dcimg_use_vt100
 # Flags to enable code optimization by the compiler.
 OPT_CFLAGS = -Ofast
 ifdef IS_GCC
+#if !defined(__loongarch__)
 OPT_CFLAGS = -Ofast -mtune=generic
+#else
+OPT_CFLAGS = -Ofast 
+#endif
 endif
 ifdef IS_ICPC
 OPT_CFLAGS = -fast


### PR DESCRIPTION
loongarch64 is a new architecture, currently there is only one cpu, so delete -mtune option