### PR TITLE
examples: probe for -mtune=generic support, fix wrong LoongArch support

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -153,11 +153,11 @@ VT100_CFLAGS = -Dcimg_use_vt100
 # Flags to enable code optimization by the compiler.
 OPT_CFLAGS = -Ofast
 ifdef IS_GCC
-#if !defined(__loongarch__)
-OPT_CFLAGS = -Ofast -mtune=generic
-#else
-OPT_CFLAGS = -Ofast 
-#endif
+# Add -mtune=generic for GCC if supported.
+NO_MTUNE_GENERIC = $(shell $(CXX) -mtune=generic -E - < /dev/null > /dev/null 2>&1; echo $$?)
+ifeq ($(NO_MTUNE_GENERIC),0)
+OPT_CFLAGS += -mtune=generic
+endif
 endif
 ifdef IS_ICPC
 OPT_CFLAGS = -fast


### PR DESCRIPTION
The commit being fixed is completely pointless, as it was introducing C
preprocessor directives into a Makefile. That aside, there certainly are
some GCC ports that does not have support for `-mtune=generic`, so probe
for support dynamically instead.

Fixes: f1996f1 ("delete -mtune option on loongarch architecture")

P.S. I came across that PR just by coincidence, I haven't looked at properly testing the library yet. Do exercise caution if you're going to directly merge this; I will try to verify the changes on actual LoongArch hardware in a day or so.