### PR TITLE
Support MSVC's OpenMP 2.0

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -339,18 +339,18 @@ enum {FALSE_WIN = 0};
 
 // Define abort macros to be used with OpenMP.
 #ifndef _cimg_abort_init_openmp
-#define _cimg_abort_init_openmp bool _cimg_abort_go_openmp = true; cimg::unused(_cimg_abort_go_openmp)
+#define _cimg_abort_init_openmp unsigned _cimg_abort_go_openmp = 1; cimg::unused(_cimg_abort_go_openmp)
 #endif
 #ifndef _cimg_abort_try_openmp
 #define _cimg_abort_try_openmp if (_cimg_abort_go_openmp) try
 #endif
 #ifndef _cimg_abort_catch_openmp
-#define _cimg_abort_catch_openmp catch (CImgAbortException&) { cimg_pragma(omp atomic) _cimg_abort_go_openmp&=false; }
+#define _cimg_abort_catch_openmp catch (CImgAbortException&) { cimg_pragma_openmp(atomic) _cimg_abort_go_openmp&=false; }
 #endif
 #ifndef _cimg_abort_catch_fill_openmp
 #define _cimg_abort_catch_fill_openmp \
   catch (CImgException& e) { cimg_pragma(omp critical(abort)) CImg<charT>::string(e._message).move_to(is_error); \
-                             cimg_pragma(omp atomic) _cimg_abort_go_openmp&=false; }
+                             cimg_pragma_openmp(atomic) _cimg_abort_go_openmp&=false; }
 #endif
 #ifdef cimg_abort_test2
 #ifndef _cimg_abort_try_openmp2


### PR DESCRIPTION
Hey @dtschump,

This PR enables using MSVC's OpenMP support. All it took was a slight adjustment to the flag type, as VC doesn't support atomic booleans (yet; I'll make sure to report it after this). I also took the chance to fix the macro used to inline the directive.