### PR TITLE
fix: compiler errors on macOS

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -19278,7 +19278,7 @@ namespace cimg_library {
               level[s - expr._data]==clevel) { // Subtraction ('-')
             _cimg_mp_op("Operator '-'");
             p1 = p2 = ~0U;
-            const ulong *ptr1 = 0, *ptr2 = 0;
+            const ulongT *ptr1 = 0, *ptr2 = 0;
             p3 = code.size();
             arg1 = compile(ss,s,depth1,0,block_flags);
             if (is_scalar(arg1) && code.size()>p3) { // Spot potential linear case 'a*b - c'


### PR DESCRIPTION
```console
./CImg.h:19281:19: error: unknown type name 'ulong'
 19281 |             const ulong *ptr1 = 0, *ptr2 = 0;
       |                   ^
./CImg.h:19281:41: error: expected ';' at end of declaration
 19281 |             const ulong *ptr1 = 0, *ptr2 = 0;
       |                                         ^
       |                                         ;
./CImg.h:19292:83: error: use of undeclared identifier 'ptr2'; did you mean 'ptr1'?
 19292 |               if (pop[0]==(ulongT)mp_mul && pop[1]==arg2) { p2 = code.size() - 1; ptr2 = pop.data(); }
       |                                                                                   ^~~~
       |                                                                                   ptr1
./CImg.h:19281:26: note: 'ptr1' declared here
 19281 |             const ulong *ptr1 = 0, *ptr2 = 0;
       |                          ^
./CImg.h:19311:42: error: use of undeclared identifier 'ptr2'; did you mean 'try'?
 19311 |                 *ptr2==(ulongT)mp_mul && ptr2[1]==(ulongT)arg2) { // Particular case 'c - a*b'
       |                                          ^~~~
       |                                          try
./CImg.h:19311:42: error: reference to overloaded function could not be resolved; did you mean to call it?
 19311 |                 *ptr2==(ulongT)mp_mul && ptr2[1]==(ulongT)arg2) { // Particular case 'c - a*b'
       |                                          ^~~~
./CImg.h:19310:52: error: use of undeclared identifier 'ptr2'
 19310 |             if (p2<code.size() && code[p2].data()==ptr2 &&
       |                                                    ^
./CImg.h:19311:18: error: use of undeclared identifier 'ptr2'
 19311 |                 *ptr2==(ulongT)mp_mul && ptr2[1]==(ulongT)arg2) { // Particular case 'c - a*b'
       |                  ^
./CImg.h:19312:36: error: use of undeclared identifier 'ptr2'; did you mean 'try'?
 19312 |               arg3 = (unsigned int)ptr2[2]; arg4 = (unsigned int)ptr2[3];
       |                                    ^~~~
       |                                    try
./CImg.h:19312:36: error: expected expression
./CImg.h:19312:66: error: use of undeclared identifier 'ptr2'; did you mean 'try'?
 19312 |               arg3 = (unsigned int)ptr2[2]; arg4 = (unsigned int)ptr2[3];
       |                                                                  ^~~~
       |                                                                  try
./CImg.h:19312:66: error: expected expression
11 errors generated.
```