### PR TITLE
Speed up cimg::fsize

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -5735,6 +5735,7 @@ namespace cimg_library {
     // Get the file or directory attributes with support for UTF-8 paths (Windows only).
 #if cimg_OS==2
     inline DWORD win_getfileattributes(const char *const path);
+    inline BOOL win_getfileattributesEx(const char* const path, WIN32_FILE_ATTRIBUTE_DATA* attr);
 #endif
 
     //! Check if a path is a directory.
@@ -67570,24 +67571,24 @@ namespace cimg_library {
        \return File size or '-1' if file does not exist.
     **/
     inline cimg_int64 fsize(std::FILE *const file) {
-      if (!file) return (cimg_int64)-1;
+      cimg_int64 siz = -1;
+      if (!file) return siz;
 
 #if cimg_OS==1 // Optimized for POSIX Environments (Linux, macOS, BSD, etc.)
       const int fd = fileno(file);
       struct stat st;
-      if (fd>=0 && !fstat(fd,&st)) return (cimg_int64)st.st_size;
-#elif cimg_OS==2 // Optimized for Windows Environments (MSVC, MinGW)
+      if (!fstat(fd,&st)) siz = (cimg_int64)st.st_size;
+#elif cimg_OS==2 // Optimized for Windows Environements (MSVC, MinGW)
       const int fd = _fileno(file);
-      if (fd>=0) {
-        const cimg_int64 siz = (cimg_int64)_filelengthi64(fd);
-        if (siz>=0) return siz;
-      }
+      siz = (cimg_int64)_filelengthi64(fd);
 #endif
       // Fallback, used for non-POSIX systems or if fstat failed (pipes or sockets).
-      const cimg_long pos = cimg::ftell(file);
-      cimg::fseek(file,0,SEEK_END);
-      const cimg_int64 siz = (cimg_int64)cimg::ftell(file);
-      cimg::fseek(file,pos,SEEK_SET);
+      if (siz < 0) {
+        const cimg_long pos = cimg::ftell(file);
+        cimg::fseek(file, 0, SEEK_END);
+        siz = (cimg_int64)cimg::ftell(file);
+        cimg::fseek(file, pos, SEEK_SET);
+      }
       return siz;
     }
 
@@ -67602,6 +67603,16 @@ namespace cimg_library {
 #if cimg_OS==1 // Optimized for POSIX Environments (Linux, macOS, BSD, etc.)
       struct stat st;
       if (!stat(filename,&st)) return (cimg_int64)st.st_size;
+#elif cimg_OS==2
+      WIN32_FILE_ATTRIBUTE_DATA attr;
+      if (win_getfileattributesEx(filename, &attr)) {
+          if (!(attr.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+              LARGE_INTEGER size;
+              size.HighPart = attr.nFileSizeHigh;
+              size.LowPart = attr.nFileSizeLow;
+              return (cimg_int64)size.QuadPart;
+          }
+      }
 #endif
       // Fallback for other systems.
       std::FILE *const file = cimg::std_fopen(filename, "rb");
@@ -67693,6 +67704,19 @@ namespace cimg_library {
         }
       }
       return res;
+    }
+
+    inline BOOL win_getfileattributesEx(const char* const path, WIN32_FILE_ATTRIBUTE_DATA* attr) {
+        BOOL res = GetFileAttributesExA(path, GetFileExInfoStandard, attr);
+        if (!res) {
+            // Try alternative method, with wide-character string.
+            int err = MultiByteToWideChar(CP_UTF8, 0, path, -1, 0, 0);
+            if (err) {
+                CImg<wchar_t> wpath((unsigned int)err);
+                if (MultiByteToWideChar(CP_UTF8, 0, path, -1, wpath, err)) res = GetFileAttributesExW(wpath, GetFileExInfoStandard, attr);
+            }
+        }
+        return res;
     }
 #endif
 


### PR DESCRIPTION
In a POSIX environment, there is a faster way to retrieve a file's size that does not modify the file offset.

This can roughly improve `fsize` performance by 3x–10x

Benchmark code:

```c++
// A 1 MiB file. However size does not matter here.
static const char* filePath = "test.bin";

typedef int64_t cimg_int64;

inline cimg_int64 fsize(std::FILE *file) {
    if (!file) return (cimg_int64)-1;
    const long pos = std::ftell(file);
    std::fseek(file,0,SEEK_END);
    const cimg_int64 siz = (cimg_int64)std::ftell(file);
    std::fseek(file,pos,SEEK_SET);
    return siz;
}
inline cimg_int64 fsize(const char *const filename) {
    std::FILE *const file = std::fopen(filename,"rb");
    const cimg_int64 siz = fsize(file);
    std::fclose(file);
    return siz;
}

inline cimg_int64 fsizeOptimize(std::FILE *file) {
    if (!file) return (cimg_int64)-1;
    int fd = fileno(file);
    struct stat st;
    if (fstat(fd, &st) < 0) return -1;
    return (cimg_int64)st.st_size;
}
inline cimg_int64 fsizeOptimize(const char *const filename) {
    struct stat st;
    if (stat(filename, &st) < 0) return -1;
    return (cimg_int64)st.st_size;
}

static void BM_fsize_FILE(benchmark::State& state) {
    FILE* fp = std::fopen(filePath, "rb");
    for (auto _ : state) {
        benchmark::DoNotOptimize(fsize(fp));
        benchmark::ClobberMemory();
    }
    std::fclose(fp);
}
BENCHMARK(BM_fsize_FILE);
static void BM_fsize_filename(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize(fsize(filePath));
        benchmark::ClobberMemory();
    }
}
BENCHMARK(BM_fsize_filename);

static void BM_fsizeOptimize_FILE(benchmark::State& state) {
    FILE* fp = std::fopen(filePath, "rb");
    for (auto _ : state) {
        benchmark::DoNotOptimize(fsizeOptimize(fp));
        benchmark::ClobberMemory();
    }
    std::fclose(fp);
}
BENCHMARK(BM_fsizeOptimize_FILE);
static void BM_fsizeOptimize_filename(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize(fsizeOptimize(filePath));
        benchmark::ClobberMemory();
    }
}
BENCHMARK(BM_fsizeOptimize_filename);
```

Results:

```console
# macOS
Run on (10 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x10)
Load Average: 2.10, 2.08, 1.88
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BM_fsize_FILE                    604 ns          604 ns      1196254
BM_fsize_filename               6182 ns         6182 ns       111123
BM_fsizeOptimize_FILE            227 ns          227 ns      3107534
BM_fsizeOptimize_filename        405 ns          405 ns      1726758

# Linux
Run on (4 X 48 MHz CPU s)
Load Average: 0.13, 0.07, 0.02
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BM_fsize_FILE                    371 ns          370 ns      1871449
BM_fsize_filename               1213 ns         1208 ns       566134
BM_fsizeOptimize_FILE            141 ns          140 ns      4872801
BM_fsizeOptimize_filename        199 ns          198 ns      3489223
```